### PR TITLE
small bugfix

### DIFF
--- a/prolog_kernel/install.py
+++ b/prolog_kernel/install.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 from jupyter_client.kernelspec import KernelSpecManager
 


### PR DESCRIPTION
the prolog_kernel.install --sys-prefix currently doesn't work.