### PR TITLE
added console entry-point

### DIFF
--- a/prolog_kernel/__main__.py
+++ b/prolog_kernel/__main__.py
@@ -1,4 +1,9 @@
 from ipykernel.kernelapp import IPKernelApp
 from prolog_kernel.kernel import PrologKernel
 
+
+def entry_point():
+    IPKernelApp.launch_instance(kernel_class=PrologKernel)
+
+
 IPKernelApp.launch_instance(kernel_class=PrologKernel)

--- a/prolog_kernel/__main__.py
+++ b/prolog_kernel/__main__.py
@@ -6,4 +6,4 @@ def entry_point():
     IPKernelApp.launch_instance(kernel_class=PrologKernel)
 
 
-IPKernelApp.launch_instance(kernel_class=PrologKernel)
+entry_point()

--- a/prolog_kernel/kernelspec/kernel.json
+++ b/prolog_kernel/kernelspec/kernel.json
@@ -1,7 +1,5 @@
 {
   "argv": [
-      "python3",
-      "-m",
       "prolog_kernel",
       "-f",
       "{connection_file}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,5 +26,8 @@ dependencies = [
   "beautifulsoup4",
 ]
 
+[project.scripts]
+prolog_kernel = "prolog_kernel.__main__:entry_point"
+
 [project.urls]
 "Homepage" = "https://github.com/anbre/prolog-jupyter-kernel"


### PR DESCRIPTION
this way the kernel can be started bei either "python3 -m prolog_kernel", or simply "prolog_kernel", which then solves the problem of different python-executable commands, like "python3", "python", or "py"