### PR TITLE
Fix for swi 9.2.2 to 9.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Additionally, the file [jupyter_server_tests.pl](./prolog_server/jupyter_server_
   - Tested with Python 3.8.10, 3.10.12, and 3.12.2
 - **Jupyter** installation with JupyterLab and/or Juypter Notebook
   - Tested with
-    - jupyter_core: 5.7.2 (Ubunt 22.04, Windows 10)
-    - jupyterlab: 4.1.5 (Ubunt 22.04, Windows 10)
-    - notebook: 7.1.2 (Ubunt 22.04, Windows 10)
+    - jupyter_core: 5.7.2 (Ubuntu 22.04, Windows 10)
+    - jupyterlab: 4.1.5 (Ubuntu 22.04, Windows 10)
+    - notebook: 7.1.2 (Ubuntu 22.04, Windows 10)
 - A **Prolog** installation for the configured implementation
   - In order to use the default configuration, SWI-Prolog is needed and needs to be on the PATH
   - Tested with version 9.2.3, 9.2.4 and 9.3.4 (Ubuntu snap) and 9.2.4 (Windows 10) SWI-Prolog and SICStus 4.5.1 (not re-tested in 2024)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Additionally, the file [jupyter_server_tests.pl](./prolog_server/jupyter_server_
 
 The installation was tested with Ubuntu 20.04 and Windows 10.
 
+April 2024
+The SWI Prolog update from 9.2.2 to 9.2.3 broke Herculog. After some amendments Herculog was tested with
+    - jupyter_core: 5.7.2
+    - jupyterlab: 4.1.5
+    - notebook: 7.1.2
+    Ubuntu 22.04 SWI Prolog snap 9.2.3, 9.2.4 and 9.3.4
+    Python 3.10.12
+
 
 ### Install
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Also see the [JupyterLab Prolog CodeMirror Extension](https://github.com/anbre/j
 
 **Note:** The project is still under development. Even though major changes are unlikely, the possibility cannot be excluded. Furthermore, no liability is accepted for correctness and completeness.
 
+In April 2024 the SWI-Prolog update from 9.2.2 to 9.2.3 broke Herculog. Some amendments were made to Herculog and were tested succesfully.
+
 
 ## Examples
 
@@ -34,27 +36,19 @@ Additionally, the file [jupyter_server_tests.pl](./prolog_server/jupyter_server_
 ### Requirements
 
 - At least **Python** 3.5
-  - Tested with Python 3.8.10
+  - Tested with Python 3.8.10, 3.10.12, and 3.12.2
 - **Jupyter** installation with JupyterLab and/or Juypter Notebook
   - Tested with
-    - jupyter_core: 4.10.0
-    - jupyterlab: 3.2.9
-    - notebook: 6.4.8
+    - jupyter_core: 5.7.2 (Ubunt 22.04, Windows 10)
+    - jupyterlab: 4.1.5 (Ubunt 22.04, Windows 10)
+    - notebook: 7.1.2 (Ubunt 22.04, Windows 10)
 - A **Prolog** installation for the configured implementation
   - In order to use the default configuration, SWI-Prolog is needed and needs to be on the PATH
-  - Tested with version 8.4.3 of SWI-Prolog and SICStus 4.5.1
+  - Tested with version 9.2.3, 9.2.4 and 9.3.4 (Ubuntu snap) and 9.2.4 (Windows 10) SWI-Prolog and SICStus 4.5.1 (not re-tested in 2024)
+  - Tested with Python 3.10.12 (Ubuntu) and 3.12.2 (Windows 10)
 - For Windows, installing **graphviz** with pip does not suffice
   - Instead, it can be installed from [here](https://graphviz.org/download/) and added to the PATH (a reboot is required afterwards)
 
-The installation was tested with Ubuntu 20.04 and Windows 10.
-
-April 2024
-The SWI Prolog update from 9.2.2 to 9.2.3 broke Herculog. After some amendments Herculog was tested with
-    - jupyter_core: 5.7.2
-    - jupyterlab: 4.1.5
-    - notebook: 7.1.2
-    Ubuntu 22.04 SWI Prolog snap 9.2.3, 9.2.4 and 9.3.4
-    Python 3.10.12
 
 
 ### Install

--- a/prolog_kernel/prolog_server/jupyter_term_handling.pl
+++ b/prolog_kernel/prolog_server/jupyter_term_handling.pl
@@ -506,13 +506,10 @@ handle_query_term(Term, IsDirective, CallRequestId, Stack, Bindings, LoopCont, C
 
 
 % replace_previous_variable_bindings(+Term, +Bindings, -UpdatedTerm, -UpdatedBindings, -Exception)
-:- if(swi).
-replace_previous_variable_bindings(Term, Bindings, UpdatedTerm, UpdatedBindings, Exception) :-
-  catch(toplevel_variables:expand_query(Term, UpdatedTerm, Bindings, UpdatedBindings), Exception, true).
-:- else.
+% Apr 2024 changed usage of the jupyter_variable_bindings functionality for both SWI-Prolog an SICStus Prolog.
 replace_previous_variable_bindings(Term, Bindings, UpdatedTerm, UpdatedBindings, Exception) :-
   catch(jupyter_variable_bindings:term_with_stored_var_bindings(Term, Bindings, UpdatedTerm, UpdatedBindings), Exception, true).
-:- endif.
+
 
 is_query_alias(retry,jupyter:retry).
 is_query_alias(cut,jupyter:cut).
@@ -699,13 +696,9 @@ assert_query_success_response(_IsDirective, ResultBindings, Output) :-
 
 
 % update_variable_bindings(+BindingsWithoutSingletons)
-:- if(swi).
-update_variable_bindings(BindingsWithoutSingletons) :-
-  toplevel_variables:expand_answer(BindingsWithoutSingletons, _NewBindings).
-:- else.
+% Apr 2024 changed usage of the jupyter_variable_bindings functionality for both SWI-Prolog an SICStus Prolog.
 update_variable_bindings(BindingsWithoutSingletons) :-
   jupyter_variable_bindings:store_var_bindings(BindingsWithoutSingletons).
-:- endif.
 
 
 % retry_message_and_output(+GoalAtom, +Output, -RetryMessageAndOutput)

--- a/prolog_kernel/prolog_server/jupyter_term_handling.pl
+++ b/prolog_kernel/prolog_server/jupyter_term_handling.pl
@@ -506,7 +506,7 @@ handle_query_term(Term, IsDirective, CallRequestId, Stack, Bindings, LoopCont, C
 
 
 % replace_previous_variable_bindings(+Term, +Bindings, -UpdatedTerm, -UpdatedBindings, -Exception)
-% Apr 2024 changed usage of the jupyter_variable_bindings functionality for both SWI-Prolog an SICStus Prolog.
+% April 2024 change - SWI-Prolog as well as SICStus Prolog use the jupyter_variable_bindings functionality.
 replace_previous_variable_bindings(Term, Bindings, UpdatedTerm, UpdatedBindings, Exception) :-
   catch(jupyter_variable_bindings:term_with_stored_var_bindings(Term, Bindings, UpdatedTerm, UpdatedBindings), Exception, true).
 
@@ -696,7 +696,7 @@ assert_query_success_response(_IsDirective, ResultBindings, Output) :-
 
 
 % update_variable_bindings(+BindingsWithoutSingletons)
-% Apr 2024 changed usage of the jupyter_variable_bindings functionality for both SWI-Prolog an SICStus Prolog.
+% April 2024 change - SWI-Prolog as well as SICStus Prolog use the jupyter_variable_bindings functionality.
 update_variable_bindings(BindingsWithoutSingletons) :-
   jupyter_variable_bindings:store_var_bindings(BindingsWithoutSingletons).
 

--- a/prolog_kernel/prolog_server/jupyter_variable_bindings.pl
+++ b/prolog_kernel/prolog_server/jupyter_variable_bindings.pl
@@ -1,11 +1,11 @@
 
 % This module provides predicates to reuse previous values of variables in a query.
 % It is based on the module toplevel_variables from SWI-Prolog (version 8.4.2).
-% The SWI-Prolog 9.2.3 update broke Herculog. The built-in SWI-Prolog functionality
-% was changed. SWI-Prolog writes Februari 2024 "If you want to hack around, simply call toplevel_variables:toplevel_var/2. Don’t blame anyone if it stops working without notice though as it is a private API."
-% For a more future proof solution the built-in SWI-Prolog functionality will no longer be used.
-% Using the functionality from this module for SWI-Prolog repaired Herculog.
-% This module will be used for both SWI-Prolog an SICStus Prolog.
+% The SWI-Prolog 9.2.3 update broke Herculog. The built-in SWI-Prolog functionality was changed by SWI.
+% SWI-Prolog writes Februari 2024 "If you want to hack around, simply call toplevel_variables:toplevel_var/2. Don’t blame anyone if it stops working without notice though as it is a private API."
+% For a more future proof solution the SWI private API built-in SWI-Prolog functionality will no longer be used in Herculog.
+% Using the functionality from this jupyter_variable_bindings module for SWI-Prolog repaired Herculog.
+% This jupyter_variable_bindings module will be used for both SWI-Prolog and SICStus Prolog.
 
 :- module(jupyter_variable_bindings,
     [store_var_bindings/1,            % store_var_bindings(+Bindings)

--- a/prolog_kernel/prolog_server/jupyter_variable_bindings.pl
+++ b/prolog_kernel/prolog_server/jupyter_variable_bindings.pl
@@ -1,7 +1,11 @@
 
 % This module provides predicates to reuse previous values of variables in a query.
 % It is based on the module toplevel_variables from SWI-Prolog (version 8.4.2).
-% As this functionality is built-in for SWI-Prolog, this module is needed for SICStus Prolog only.
+% The SWI-Prolog 9.2.3 update broke Herculog. The built-in SWI-Prolog functionality
+% was changed. SWI-Prolog writes Februari 2024 "If you want to hack around, simply call toplevel_variables:toplevel_var/2. Don’t blame anyone if it stops working without notice though as it is a private API."
+% For a more future proof solution the built-in SWI-Prolog functionality will no longer be used.
+% Using the functionality from this module for SWI-Prolog repaired Herculog.
+% This module will be used for both SWI-Prolog an SICStus Prolog.
 
 :- module(jupyter_variable_bindings,
     [store_var_bindings/1,            % store_var_bindings(+Bindings)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
 ]
 
 [project]
-name = "prolog_kernel"
+name = "wldwrk-prolog_kernel"
 version = "0.0.10"
 authors = [ { name="Anne Brecklinghaus" }, {name="Michael Leuschel"}, {name="dgelessus"} ]
 description = "Extensible Jupyter kernel for (SWI- and SICStus) Prolog"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "prolog_kernel"
-version = "0.0.9"
+version = "0.0.10"
 authors = [ { name="Anne Brecklinghaus" }, {name="Michael Leuschel"}, {name="dgelessus"} ]
 description = "Extensible Jupyter kernel for (SWI- and SICStus) Prolog"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
 ]
 
 [project]
-name = "wldwrk-prolog_kernel"
+name = "prolog_kernel"
 version = "0.0.10"
 authors = [ { name="Anne Brecklinghaus" }, {name="Michael Leuschel"}, {name="dgelessus"} ]
 description = "Extensible Jupyter kernel for (SWI- and SICStus) Prolog"


### PR DESCRIPTION
Amendments to Herculog to repair after the SWI-Prolog update from 9.2.2 to 9.2.3 broke Herculog.